### PR TITLE
gsma: should replace DFSPID placeholder when starting gsma_base_trans…

### DIFF
--- a/src/main/java/org/mifos/connector/channel/camel/routes/GSMAChannelRouteBuilder.java
+++ b/src/main/java/org/mifos/connector/channel/camel/routes/GSMAChannelRouteBuilder.java
@@ -146,7 +146,8 @@ public class GSMAChannelRouteBuilder extends ErrorHandlerRouteBuilder {
 
                     extraVariables.put(GSMA_CHANNEL_REQUEST, objectMapper.writeValueAsString(gsmaChannelRequest));
 
-                    String transactionId = zeebeProcessStarter.startZeebeWorkflow(baseTransaction,
+                    String tenantSpecificBpmn = baseTransaction.replace("{dfspid}", tenantId);
+                    String transactionId = zeebeProcessStarter.startZeebeWorkflow(tenantSpecificBpmn,
                             objectMapper.writeValueAsString(channelRequest),
                             extraVariables);
                     JSONObject response = new JSONObject();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,7 +14,7 @@ bpmn:
     special-payment-transfer: "SpecialPayerFundTransfer-{dfspid}"
     transaction-request: "PayeeTransactionRequest-{dfspid}"
     party-registration: "PartyRegistration-{dfspid}"
-    gsma-base-transaction: "gsma_base_transaction"
+    gsma-base-transaction: "gsma_base_transaction-{dfspid}"
     gsma-int-transfer: "gsma_int_transfer"
     gsma-payee-process: "gsma_payee_process"
     gsma-bill-payment: "gsma_bill_payment"


### PR DESCRIPTION
…action-DFSPID workflow


I was trying this endpoint and it reported unknown workflow 'gsma_base_transaction' (as configured). I noticed in https://github.com/openMF/ph-ee-connector-gsma-mm/blob/develop/bpmns/gsma-p2p-wo-local-quote.bpmn that it has -DFSPID like the other workflows, so it seems like this have the DFSPID placeholder, and when starting the workflow, replace the placeholder with the tenant

I'm still working things out, happy for any feedback / review