### PR TITLE
Github Actions: check we can build the docker image

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,3 +8,5 @@ jobs:
         uses: actions/checkout@v2
       - name: Assemble project
         run: ./gradlew clean build
+      - name: Build Docker image
+        run: docker build . -t paymenthubee.mifos.io/phee/connector-channel

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,5 @@
 name: Test
-on: [push]
+on: [push, pull_request]
 jobs:
   Assemble:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This adds
 - the missing `pull_request` trigger event to the Github Actions workflow
 - a Github Actions step to build the docker image
