### PR TITLE
Updating BPMN name structure

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,7 +35,7 @@ bpmn:
     gsma-link-based-payment: "gsma_link_transfer"
     international-remittance-payee: "international-remittance-payee-process-{dfspid}"
     international-remittance-payer: "international-remittance-payer-process-{dfspid}"
-    mpesa-flow: "mpesa_flow-{ams}-{dfspid}"
+    mpesa-flow: "mpesa_flow_{ams}-{dfspid}"
 
 
 ams:


### PR DESCRIPTION
This PR includes changes in bpmn name structure in order to adhere to the following standard of naming the bpmn:


`Name of the entire bpmn will incloude no special character except - and _.
Each word will be separated by an _ (underscore).
Each bpmn name would be suffixed by -DFSPID , where DFSPID is tenant name.
example:
Valid name: international_remittance_payer_process-ibank-usa
Invalid name: international-remittance-payer-process-ibank-india `

@avikganguly01 