### PR TITLE
Tomcat server port reverted back to 8080

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 camel:
-  server-port: 5001
+  server-port: 5000
   springboot:
     main-run-controller: true
   dataformat:
@@ -65,7 +65,7 @@ zeebe:
     contactpoint: "localhost:26500"
 
 server:
-  port: 8081
+  port: 8080
 
 rest:
   authorization:


### PR DESCRIPTION
## Description

* Reverted PORT related changes in https://github.com/openMF/ph-ee-connector-channel/commit/703860ab21f5b4f8505e033fceced1869f38ee0f#diff-7bc26be01d3e7c9c566f2a28dc1b5cd87dbdd5cb619184f46eb2bf223bf7825d
* Tomcat port changes from 8081 >> 8080.
* Undertow port changes from 5001 >> 5000

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Design related bullet points or design document link related to this PR added in the description above. 

- [x] Updated corresponding Postman Collection or Api documentation for the changes in this PR.

- [x] Create/update unit or integration tests for verifying the changes made.

- [x] Add required Swagger annotation and update API documentation with details of any API changes if applicable

- [x] Followed the naming conventions as given in https://docs.google.com/document/d/1Q4vaMSzrTxxh9TS0RILuNkSkYCxotuYk1Xe0CMIkkCU/edit?usp=sharing
