### PR TITLE
Added correlation id for collection, gsma p2p, and international remittance

### DIFF
--- a/src/main/java/org/mifos/connector/channel/camel/routes/ChannelRouteBuilder.java
+++ b/src/main/java/org/mifos/connector/channel/camel/routes/ChannelRouteBuilder.java
@@ -300,6 +300,7 @@ public class ChannelRouteBuilder extends ErrorHandlerRouteBuilder {
                     extraVariables.put("scenario", "MPESA");
 
                     String tenantId = exchange.getIn().getHeader("Platform-TenantId", String.class);
+                    String clientCorrelationId = exchange.getIn().getHeader("X-CorrelationID", String.class);
                     if (tenantId == null || !dfspIds.contains(tenantId)) {
                         throw new RuntimeException("Requested tenant " + tenantId + " not configured in the connector!");
                     }
@@ -357,6 +358,7 @@ public class ChannelRouteBuilder extends ErrorHandlerRouteBuilder {
                     extraVariables.put("isNotificationsSuccessEnabled", isNotificationSuccessServiceEnabled);
                     extraVariables.put("isNotificationsFailureEnabled", isNotificationFailureServiceEnabled);
                     extraVariables.put("timer",timer);
+                    extraVariables.put("clientCorrelationId", clientCorrelationId);
 
 
                     String transactionId = zeebeProcessStarter.startMpesaZeebeWorkflow(tenantSpecificBpmn,

--- a/src/main/java/org/mifos/connector/channel/camel/routes/GSMAChannelRouteBuilder.java
+++ b/src/main/java/org/mifos/connector/channel/camel/routes/GSMAChannelRouteBuilder.java
@@ -115,7 +115,7 @@ public class GSMAChannelRouteBuilder extends ErrorHandlerRouteBuilder {
                 .process(exchange -> {
                     GSMATransaction gsmaChannelRequest = exchange.getIn().getBody(GSMATransaction.class); // GSMA Object
                     TransactionChannelRequestDTO channelRequest = new TransactionChannelRequestDTO(); // Fineract Object
-
+                    String clientCorrelationId = exchange.getIn().getHeader("X-CorrelationID", String.class);
                     Party payer = partyMapper(gsmaChannelRequest.getDebitParty());
                     Party payee = partyMapper(gsmaChannelRequest.getCreditParty());
                     MoneyData amount = amountMapper(gsmaChannelRequest.getAmount(), gsmaChannelRequest.getCurrency());
@@ -139,6 +139,7 @@ public class GSMAChannelRouteBuilder extends ErrorHandlerRouteBuilder {
                             channelRequest.getAmount().getCurrency()));
                     extraVariables.put("processType","api");
                     extraVariables.put("payeeTenantId", "lion");
+                    extraVariables.put("clientCorrelationId", clientCorrelationId);
 
                     String tenantId = exchange.getIn().getHeader("Platform-TenantId", String.class);
                     extraVariables.put(TENANT_ID, tenantId);
@@ -214,7 +215,7 @@ public class GSMAChannelRouteBuilder extends ErrorHandlerRouteBuilder {
                 .process(exchange -> {
                     GSMATransaction gsmaChannelRequest = exchange.getIn().getBody(GSMATransaction.class); // GSMA Object
                     TransactionChannelRequestDTO channelRequest = new TransactionChannelRequestDTO(); // Fineract Object
-
+                    String clientCorrelationId = exchange.getIn().getHeader("X-CorrelationID", String.class);
                     Party payer = partyMapper(gsmaChannelRequest.getDebitParty());
                     Party payee = partyMapper(gsmaChannelRequest.getCreditParty());
                     MoneyData amount = amountMapper(gsmaChannelRequest.getAmount(), gsmaChannelRequest.getCurrency());
@@ -241,6 +242,7 @@ public class GSMAChannelRouteBuilder extends ErrorHandlerRouteBuilder {
                     gsmaResponse.setNotificationMethod("polling");
                     gsmaResponse.setObjectReference("");
                     gsmaResponse.setPollLimit("");
+                    extraVariables.put("clientCorrelationId", clientCorrelationId);
 
                     exchange.getIn().setBody(objectMapper.writeValueAsString(gsmaResponse));
                     exchange.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, constant(202));


### PR DESCRIPTION
## Description

* Added logic to add zeebe variables for cleint correlation id by picking up from header. 
* Affects following apis:

1. Collection Request
2. GSMA P2P (Payer Side)
3. Intl Remittance Payee 



 _(Ignore if these details are present on the associated JIRA ticket)_

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] Design related bullet points or design document link related to this PR added in the description above. 

- [X] Updated corresponding Postman Collection or Api documentation for the changes in this PR.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [X] Add required Swagger annotation and update API documentation with details of any API changes if applicable

- [X] Followed the naming conventions as given in https://docs.google.com/document/d/1Q4vaMSzrTxxh9TS0RILuNkSkYCxotuYk1Xe0CMIkkCU/edit?usp=sharing

@avikganguly01 @fynmanoj 